### PR TITLE
DEV-2814 cleanup files before running tests

### DIFF
--- a/bdd/client_labels/e2e_test.go
+++ b/bdd/client_labels/e2e_test.go
@@ -127,5 +127,6 @@ func (suite *TagsAndLabelsTestSuite) callURL(requestURL string) Rsp {
 // In order for 'go test' to run this suite, we need to create
 // a normal test function and pass our suite to suite.Run
 func TestTagsAndLabelsTestSuite(t *testing.T) {
+	helpers.CleanUp(t, "./rc-test-resurces", "./rd-test-resources")
 	suite.Run(t, new(TagsAndLabelsTestSuite))
 }

--- a/bdd/helpers/cleanup.go
+++ b/bdd/helpers/cleanup.go
@@ -1,0 +1,13 @@
+package helpers
+
+import (
+	"os"
+	"testing"
+)
+
+func CleanUp(t *testing.T, pathsToRemove ...string) {
+	t.Log("cleaning before test")
+	for _, path := range pathsToRemove {
+		t.Log("removing", path, os.RemoveAll(path))
+	}
+}

--- a/bdd/simple_client_connects/e2e_test.go
+++ b/bdd/simple_client_connects/e2e_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestClientConnects(t *testing.T) {
+	helpers.CleanUp(t, "./rc-test-resurces", "./rd-test-resources")
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 	defer cancel()


### PR DESCRIPTION
Because tests fail if there are some leftovers after previous runs
(most likely in the db)  