### PR TITLE
[DEV-2843] Remove api session related data races

### DIFF
--- a/server/api/session/cache.go
+++ b/server/api/session/cache.go
@@ -81,8 +81,8 @@ func (p *Cache) Close() error {
 }
 
 func (p *Cache) getFromCache(sessionID int64) (found bool, sessionInfo APISession, err error) {
-	existingObj, _ := p.cache.Get(formatID(sessionID))
-	if existingObj == nil {
+	existingObj, found := p.cache.Get(formatID(sessionID))
+	if !found {
 		return false, APISession{}, nil
 	}
 

--- a/server/api/session/session.go
+++ b/server/api/session/session.go
@@ -18,8 +18,8 @@ type APISession struct {
 
 // current implementation provided by go-cache
 type InternalCacheProvider interface {
-	Set(k string, x interface{}, d time.Duration)
-	Get(k string) (interface{}, bool)
+	Set(k string, item interface{}, d time.Duration)
+	Get(k string) (item interface{}, found bool)
 	Delete(k string)
 	ItemCount() int
 	// using `cache.Item` creates a interface dependency on go-cache but currently

--- a/server/api/session/session.go
+++ b/server/api/session/session.go
@@ -29,9 +29,9 @@ type InternalCacheProvider interface {
 }
 
 type StorageProvider interface {
-	Get(ctx context.Context, sessionID int64) (*APISession, error)
-	GetAll(ctx context.Context) ([]*APISession, error)
-	Save(ctx context.Context, session *APISession) (sessionID int64, err error)
+	Get(ctx context.Context, sessionID int64) (found bool, sessionInfo APISession, err error)
+	GetAll(ctx context.Context) ([]APISession, error)
+	Save(ctx context.Context, session APISession) (sessionID int64, err error)
 	Delete(ctx context.Context, sessionID int64) error
 	DeleteExpired(ctx context.Context) error
 	Close() error

--- a/server/api_handler_users_test.go
+++ b/server/api_handler_users_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 type UserAPISessionsResponse struct {
-	Data []*session.APISession
+	Data []session.APISession
 }
 
 func TestShouldHandleGetAllUserAPISessions(t *testing.T) {

--- a/server/api_middleware.go
+++ b/server/api_middleware.go
@@ -187,13 +187,13 @@ func (al *APIListener) updateTokenAccess(ctx context.Context, token string, acce
 		return err
 	}
 
-	sessionInfo, err := al.apiSessions.Get(ctx, tokenCtx.AppClaims.SessionID)
+	found, sessionInfo, err := al.apiSessions.Get(ctx, tokenCtx.AppClaims.SessionID)
 	if err != nil {
 		return err
 	}
 
 	// if no session cache yet, then don't try to update
-	if sessionInfo == nil {
+	if !found {
 		return nil
 	}
 


### PR DESCRIPTION
https://tracker.rport.io/issue/DEV-2843/Remove-api-session-related-data-races

This implementation uses struct copies rather than mutexes. What do we think about this?