### PR TITLE
DEV-2932/schedules-based-on-tags-broken

### DIFF
--- a/server/api/jobs/schedule/manager.go
+++ b/server/api/jobs/schedule/manager.go
@@ -305,6 +305,7 @@ func (m *Manager) run(ctx context.Context, id string) {
 		ScheduleID:          &schedule.ID,
 		Username:            schedule.CreatedBy,
 		ClientIDs:           schedule.Details.ClientIDs,
+		ClientTags:          schedule.Details.ClientTags,
 		GroupIDs:            schedule.Details.GroupIDs,
 		Command:             schedule.Details.Command,
 		Script:              schedule.Details.Script,


### PR DESCRIPTION
add missing manual copy of tag property